### PR TITLE
Bottom overflow bug consertado

### DIFF
--- a/bety_app/lib/screens/cadastro_screen.dart
+++ b/bety_app/lib/screens/cadastro_screen.dart
@@ -190,6 +190,7 @@ class _CadastroScreenState extends State<CadastroScreen> {
           ),
         ),
       ),
+      resizeToAvoidBottomInset: false
     );
   }
 

--- a/bety_app/lib/screens/login.dart
+++ b/bety_app/lib/screens/login.dart
@@ -99,6 +99,7 @@ class _LoginScreenState extends State<LoginScreen> {
           ),
         ),
       ),
+      resizeToAvoidBottomInset: false
     );
   }
 }


### PR DESCRIPTION
Bug do aviso de bottom overflow presente tanto na tela de login quanto na tela de cadastro ao ao abrir o teclado do dispositivo móvel foi consertado, adicionado resizeToAvoidBottomInset: false logo depois de fechar o body com o padding.